### PR TITLE
fix: improve test title extraction from Cypress files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,52 +2,39 @@ import fs from 'fs';
 import path from 'path';
 import { parseCypressTestFile } from './parser';
 
-/**
- * Recursively finds files matching the pattern in a directory
- * @param dir Directory to search in
- * @param pattern Regex pattern to match file names
- * @returns Array of matching file paths
- */
 function findFilesRecursively(dir: string, pattern: RegExp): string[] {
   let results: string[] = [];
-  
-  // Read directory contents
+
   const items = fs.readdirSync(dir);
-  
+
   for (const item of items) {
     const itemPath = path.join(dir, item);
     const stat = fs.statSync(itemPath);
-    
+
     if (stat.isDirectory()) {
-      // Skip node_modules and hidden directories
       if (item !== 'node_modules' && !item.startsWith('.')) {
         results = results.concat(findFilesRecursively(itemPath, pattern));
       }
-    } 
+    }
     else if (stat.isFile() && pattern.test(item)) {
-      // Add matching files to results
       results.push(itemPath);
     }
   }
-  
+
   return results;
 }
 
-// Find all Cypress test files (.cy.js/ts, .spec.js/ts, and .test.js/ts)
 const filePattern = /\.(cy|spec|test)\.(js|ts)$/;
 const testFiles = findFilesRecursively('.', filePattern);
 
-// Initialize markdown document
 let markdown = `# Cypress Test Documentation\n\n`;
 
-// Group files by type for statistics
 const groupedFiles = {
   cypress: testFiles.filter(file => file.includes('.cy.')),
   spec: testFiles.filter(file => file.includes('.spec.')),
   test: testFiles.filter(file => file.includes('.test.'))
 };
 
-// Add summary section with statistics
 markdown += `## Summary\n\n`;
 markdown += `- Total Test Files: **${testFiles.length}**\n`;
 markdown += `- Cypress Files (.cy): **${groupedFiles.cypress.length}**\n`;
@@ -55,34 +42,28 @@ markdown += `- Spec Files (.spec): **${groupedFiles.spec.length}**\n`;
 markdown += `- Test Files (.test): **${groupedFiles.test.length}**\n\n`;
 markdown += `---\n\n`;
 
-// Process each test file
 testFiles.forEach(filePath => {
   const result = parseCypressTestFile(filePath);
 
-  // Add file information
   markdown += `## File: **${result.fileName}**\n\n`;
   markdown += `**Path:** ${result.filePath}\n\n`;
-  
-  // Include metadata if available
+
   if (result.description) {
     markdown += `**Description:** ${result.description}\n`;
   }
-  
+
   if (result.author) {
     markdown += `**Author:** ${result.author}\n\n`;
   }
-  
-  // Include describe block if present
+
   if (result.describe !== 'N/A') {
     markdown += `## Describe: **${result.describe}**\n\n`;
   }
-  
-  // Include context block if present
+
   if (result.context) {
     markdown += `### Context: **${result.context}**\n\n`;
   }
-  
-  // List test cases
+
   markdown += `#### Tests\n`;
   result.its.forEach(it => {
     markdown += `- ${it}\n`;
@@ -91,7 +72,6 @@ testFiles.forEach(filePath => {
   markdown += `\n---\n\n`;
 });
 
-// Write documentation to file
 fs.writeFileSync('spec-docs.md', markdown);
 console.log('✅ spec-docs.md generated successfully!');
 console.log(`Found ${testFiles.length} test files (${groupedFiles.cypress.length} .cy files, ${groupedFiles.spec.length} .spec files, ${groupedFiles.test.length} .test files).`);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,51 +2,39 @@ import fs from 'fs';
 import path from 'path';
 import { IParsedTestFile } from './types';
 
-/**
- * Parses a Cypress test file to extract metadata and test information
- * @param filePath Path to the test file
- * @returns Structured test data
- */
 export function parseCypressTestFile(filePath: string): IParsedTestFile {
   const content = fs.readFileSync(filePath, 'utf8');
   const fileName = path.basename(filePath);
   const relativePath = path.relative(process.cwd(), filePath);
   const fileExtension = path.extname(filePath);
 
-  // Determine file type based on file name
   let fileType = 'other';
   if (fileName.includes('.cy.')) fileType = 'cypress';
   else if (fileName.includes('.spec.')) fileType = 'spec';
   else if (fileName.includes('.test.')) fileType = 'test';
 
-  // Extract test structure with regular expressions
   const describeMatch = content.match(/describe\s*\(\s*['"`](.*?)['"`]/);
   const contextMatch = content.match(/context\s*\(\s*['"`](.*?)['"`]/);
 
-  // Extract test titles while filtering out unwanted content
   const itTitles = [];
   const requestInterceptCalls = new Set<string>();
   const testBlocks = content.split(/it\s*\(\s*['"]/);
 
   console.log(`File: ${fileName} - Found ${testBlocks.length - 1} potential test blocks`);
 
-  // Skip the first element (preamble)
   for (let i = 1; i < testBlocks.length; i++) {
-    // Extract the title until the next string delimiter
     const titleMatch = testBlocks[i].match(/^(.*?)['"`]/);
     if (titleMatch && titleMatch[1]) {
       const title = titleMatch[1].trim();
       console.log(`Test block ${i}: Title extracted: "${title}"`);
 
-      // Filter out URLs, Cypress commands, intercept/request aliases (starting with @), and single-letter titles
       if (!title.startsWith('/') &&
         !title.startsWith('cy.') &&
         !title.startsWith('@') &&
-        title.length > 1) { // Require at least 2 characters
+        title.length > 1) {
         itTitles.push(title);
         console.log(`Added test: "${title}"`);
       } else if (title.startsWith('@')) {
-        // Save intercept/request calls separately
         requestInterceptCalls.add(title);
         console.log(`Skipped intercept/request: "${title}"`);
       } else if (title.length <= 1) {
@@ -59,25 +47,21 @@ export function parseCypressTestFile(filePath: string): IParsedTestFile {
     }
   }
 
-  // Extract JSDoc comments
   let description = '';
   let author = '';
 
-  // Find JSDoc comment blocks
   const jsDocPattern = /\/\*\*([\s\S]*?)\*\//g;
   let jsDocMatch;
 
   while ((jsDocMatch = jsDocPattern.exec(content)) !== null) {
     const jsDocContent = jsDocMatch[1];
 
-    // Extract description
     const descPattern = /@description\s+(.*?)(?=\s*\*\s*@|\s*\*\/|$)/s;
     const descMatch = jsDocContent.match(descPattern);
     if (descMatch && descMatch[1]) {
       description = descMatch[1].replace(/\s*\*\s*/g, ' ').trim();
     }
 
-    // Extract author
     const authorPattern = /@author\s+(.*?)(?=\s*\*\s*@|\s*\*\/|$)/s;
     const authorMatch = jsDocContent.match(authorPattern);
     if (authorMatch && authorMatch[1]) {
@@ -85,16 +69,14 @@ export function parseCypressTestFile(filePath: string): IParsedTestFile {
     }
   }
 
-  // Log for debugging
   console.log(`File: ${fileName}`);
   console.log(`Description: "${description}"`);
   console.log(`Author: "${author}"`);
   console.log(`Tests found: ${itTitles.length}`);
   console.log(`Tests: ${JSON.stringify(itTitles)}`);
 
-  // Set default values if patterns aren't found
   const describe = describeMatch?.[1] ?? 'N/A';
-  const context = contextMatch?.[1] ?? ''; // Only set if explicitly present
+  const context = contextMatch?.[1] ?? '';
 
   return {
     fileName,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -12,7 +12,7 @@ export function parseCypressTestFile(filePath: string): IParsedTestFile {
   const fileName = path.basename(filePath);
   const relativePath = path.relative(process.cwd(), filePath);
   const fileExtension = path.extname(filePath);
-  
+
   // Determine file type based on file name
   let fileType = 'other';
   if (fileName.includes('.cy.')) fileType = 'cypress';
@@ -22,43 +22,61 @@ export function parseCypressTestFile(filePath: string): IParsedTestFile {
   // Extract test structure with regular expressions
   const describeMatch = content.match(/describe\s*\(\s*['"`](.*?)['"`]/);
   const contextMatch = content.match(/context\s*\(\s*['"`](.*?)['"`]/);
-  
+
   // Extract test titles while filtering out unwanted content
   const itTitles = [];
+  const requestInterceptCalls = new Set<string>();
   const testBlocks = content.split(/it\s*\(\s*['"]/);
-  
+
+  console.log(`File: ${fileName} - Found ${testBlocks.length - 1} potential test blocks`);
+
   // Skip the first element (preamble)
   for (let i = 1; i < testBlocks.length; i++) {
     // Extract the title until the next string delimiter
     const titleMatch = testBlocks[i].match(/^(.*?)['"`]/);
     if (titleMatch && titleMatch[1]) {
       const title = titleMatch[1].trim();
-      
-      // Filter out URLs and Cypress commands
-      if (!title.startsWith('/') && !title.startsWith('cy.') && title.length > 0) {
+      console.log(`Test block ${i}: Title extracted: "${title}"`);
+
+      // Filter out URLs, Cypress commands, intercept/request aliases (starting with @), and single-letter titles
+      if (!title.startsWith('/') &&
+        !title.startsWith('cy.') &&
+        !title.startsWith('@') &&
+        title.length > 1) { // Require at least 2 characters
         itTitles.push(title);
+        console.log(`Added test: "${title}"`);
+      } else if (title.startsWith('@')) {
+        // Save intercept/request calls separately
+        requestInterceptCalls.add(title);
+        console.log(`Skipped intercept/request: "${title}"`);
+      } else if (title.length <= 1) {
+        console.log(`Skipped single-letter title: "${title}"`);
+      } else {
+        console.log(`Skipped title due to filtering rules: "${title}"`);
       }
+    } else {
+      console.log(`Test block ${i}: No title match found`);
     }
   }
-  
+
   // Extract JSDoc comments
   let description = '';
   let author = '';
-  
+
   // Find JSDoc comment blocks
   const jsDocPattern = /\/\*\*([\s\S]*?)\*\//g;
   let jsDocMatch;
-  
+
   while ((jsDocMatch = jsDocPattern.exec(content)) !== null) {
     const jsDocContent = jsDocMatch[1];
-    
+
     // Extract description
     const descPattern = /@description\s+(.*?)(?=\s*\*\s*@|\s*\*\/|$)/s;
     const descMatch = jsDocContent.match(descPattern);
     if (descMatch && descMatch[1]) {
       description = descMatch[1].replace(/\s*\*\s*/g, ' ').trim();
     }
-    
+
     // Extract author
     const authorPattern = /@author\s+(.*?)(?=\s*\*\s*@|\s*\*\/|$)/s;
     const authorMatch = jsDocContent.match(authorPattern);
@@ -66,12 +84,14 @@ export function parseCypressTestFile(filePath: string): IParsedTestFile {
       author = authorMatch[1].replace(/\s*\*\s*/g, ' ').trim();
     }
   }
-  
+
   // Log for debugging
   console.log(`File: ${fileName}`);
   console.log(`Description: "${description}"`);
   console.log(`Author: "${author}"`);
-  
+  console.log(`Tests found: ${itTitles.length}`);
+  console.log(`Tests: ${JSON.stringify(itTitles)}`);
+
   // Set default values if patterns aren't found
   const describe = describeMatch?.[1] ?? 'N/A';
   const context = contextMatch?.[1] ?? ''; // Only set if explicitly present

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,9 @@
 export interface IParsedTestFile {
-    fileName: string;
-    filePath: string;
-    describe: string;
-    context: string;
-    its: string[];
-    description: string;
-    author: string;
-  }
-  
+  fileName: string;
+  filePath: string;
+  describe: string;
+  context: string;
+  its: string[];
+  description: string;
+  author: string;
+}


### PR DESCRIPTION
This fix refactors the Cypress test file parsing function to enhance test title extraction. Key improvements include:

- Filtering out Cypress commands, URLs, and single-letter titles

- Adding debug logs for better traceability and debugging

- Updating the IParsedTestFile interface to ensure consistent data formatting

These changes improve the accuracy and reliability of the parser when handling various test patterns.